### PR TITLE
Fix #48: Handle empty system or series option sets in fossil form selects

### DIFF
--- a/javascript/src/Admin/Fossil/SystemSeriesStageSelect.js
+++ b/javascript/src/Admin/Fossil/SystemSeriesStageSelect.js
@@ -80,9 +80,9 @@ export default class SystemSeriesStageSelect {
 
     _addSeriesAndStageOptions() {
         const initialSeriesSet = this._findOptionSet(this.systemSelect.item(this.systemSelect.selectedIndex).dataset.id, this.allSeriesOptions);
-        this._addOptions(this.seriesSelect, Object.values(initialSeriesSet));
+        this._addOptions(this.seriesSelect, initialSeriesSet ? Object.values(initialSeriesSet) : []);
         const initialStageSet = this._findOptionSet(this.seriesSelect.item(this.seriesSelect.selectedIndex).dataset.id, this.allStageOptions);
-        this._addOptions(this.stageSelect, Object.values(initialStageSet));
+        this._addOptions(this.stageSelect, initialStageSet ? Object.values(initialStageSet) : []);
     }
 
     _addPlaceholderOption(select) {


### PR DESCRIPTION
## DE

### Problem
The issue is a JavaScript TypeError in SystemSeriesStageSelect.js where Object.values() is called on undefined values returned by _findOptionSet(). An existing PR #51 has the correct fix but E2E tests are failing, requiring human review.

### Diagnose
The issue is confirmed in javascript/src/Admin/Fossil/SystemSeriesStageSelect.js lines 82-85 where Object.values(initialSeriesSet) and Object.values(initialStageSet) are called. The _findOptionSet() method can return undefined when no options exist for a parent key, causing TypeError during form initialization. The PR #51 contains the correct fix with null/undefined checks before Object.values() calls.

### Fixplan
- The fix is already implemented in PR #51: add null/undefined checks before calling Object.values()
- Modify lines 82-85 in _addSeriesAndStageOptions() method to handle undefined return values
- Use conditional checks: initialSeriesSet ? Object.values(initialSeriesSet) : []
- Same pattern for initialStageSet to provide empty arrays as fallback

### Verifikation
- Test fossil form with systems that have no series
- Test fossil form with series that have no stages
- Verify no JavaScript errors occur during form initialization
- Confirm dependent selects show placeholder when no child options exist
- Test that dependent selects still work correctly when valid options are available

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a frontend JavaScript bug that would require browser-based E2E testing with specific data scenarios. The existing project uses Playwright for E2E tests, but creating a test for this edge case would require setting up test data with systems without series, which is beyond the scope of a simple unit test.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 4
- Geaenderte Dateien: javascript/src/Admin/Fossil/SystemSeriesStageSelect.js

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-48/artefacts-20260610-082913`

## EN

### Problem
The issue is a JavaScript TypeError in SystemSeriesStageSelect.js where Object.values() is called on undefined values returned by _findOptionSet(). An existing PR #51 has the correct fix but E2E tests are failing, requiring human review.

### Diagnosis
The issue is confirmed in javascript/src/Admin/Fossil/SystemSeriesStageSelect.js lines 82-85 where Object.values(initialSeriesSet) and Object.values(initialStageSet) are called. The _findOptionSet() method can return undefined when no options exist for a parent key, causing TypeError during form initialization. The PR #51 contains the correct fix with null/undefined checks before Object.values() calls.

### Fix Plan
- The fix is already implemented in PR #51: add null/undefined checks before calling Object.values()
- Modify lines 82-85 in _addSeriesAndStageOptions() method to handle undefined return values
- Use conditional checks: initialSeriesSet ? Object.values(initialSeriesSet) : []
- Same pattern for initialStageSet to provide empty arrays as fallback

### Verification
- Test fossil form with systems that have no series
- Test fossil form with series that have no stages
- Verify no JavaScript errors occur during form initialization
- Confirm dependent selects show placeholder when no child options exist
- Test that dependent selects still work correctly when valid options are available

### Test Coverage
- Test included: no
- Reason: This is a frontend JavaScript bug that would require browser-based E2E testing with specific data scenarios. The existing project uses Playwright for E2E tests, but creating a test for this edge case would require setting up test data with systems without series, which is beyond the scope of a simple unit test.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 4
- Changed files: javascript/src/Admin/Fossil/SystemSeriesStageSelect.js

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-48/artefacts-20260610-082913`

Closes #48
