### PR TITLE
Fix #57: Show delete failures as errors for series and stages

### DIFF
--- a/src/Controller/Administration/SeriesController.php
+++ b/src/Controller/Administration/SeriesController.php
@@ -93,7 +93,9 @@ class SeriesController extends AbstractController
         try {
             $this->earthAgeSeriesRepository->delete($series);
         } catch (\Exception $exception) {
-            $this->addFlash(Defaults::FLASH_TYPE_SUCCESS, $this->translator->trans('admin.genericError') . $exception->getMessage());
+            $this->addFlash(Defaults::FLASH_TYPE_ERROR, $this->translator->trans('admin.genericError') . $exception->getMessage());
+
+            return $this->redirectToRoute('app_admin_series');
         }
 
         $this->addFlash(Defaults::FLASH_TYPE_SUCCESS, sprintf($this->translator->trans('admin.series.messages.seriesDeleted'), $series->getName()));

--- a/src/Controller/Administration/StageController.php
+++ b/src/Controller/Administration/StageController.php
@@ -93,7 +93,9 @@ class StageController extends AbstractController
         try {
             $this->earthAgeStageRepository->delete($stage);
         } catch (\Exception $exception) {
-            $this->addFlash(Defaults::FLASH_TYPE_SUCCESS, $this->translator->trans('admin.genericError') . $exception->getMessage());
+            $this->addFlash(Defaults::FLASH_TYPE_ERROR, $this->translator->trans('admin.genericError') . $exception->getMessage());
+
+            return $this->redirectToRoute('app_admin_series');
         }
 
         $this->addFlash(Defaults::FLASH_TYPE_SUCCESS, sprintf($this->translator->trans('admin.stage.messages.stageDeleted'), $stage->getName()));


### PR DESCRIPTION
## DE

### Problem
Delete exceptions in SeriesController and StageController incorrectly use FLASH_TYPE_SUCCESS instead of FLASH_TYPE_ERROR, and success messages are shown unconditionally after exceptions.

### Diagnose
Both StageController.php:93-100 and SeriesController.php:93-100 have catch blocks that use FLASH_TYPE_SUCCESS for exceptions, and the success message is added unconditionally after the try-catch block, causing users to see success messages even when deletion fails.

### Fixplan
- Change FLASH_TYPE_SUCCESS to FLASH_TYPE_ERROR in both catch blocks
- Add early return after exception handling to prevent success message
- Ensure successful deletes still show success message as before

### Verifikation
- Test successful series/stage deletion shows success message
- Test failed series/stage deletion shows error message only
- Run existing PHPUnit tests to ensure no regressions
- Verify PHP CS Fixer and PHPStan pass

### Testabdeckung
- Test enthalten: nein
- Begruendung: No existing test infrastructure for controller flash messages found in repository context. Adding controller tests would require significant test setup not present in current codebase.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 2
- Produktive Zeilen: 8
- Geaenderte Dateien: src/Controller/Administration/SeriesController.php, src/Controller/Administration/StageController.php

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-57/artefacts-20260615-090815`

## EN

### Problem
Delete exceptions in SeriesController and StageController incorrectly use FLASH_TYPE_SUCCESS instead of FLASH_TYPE_ERROR, and success messages are shown unconditionally after exceptions.

### Diagnosis
Both StageController.php:93-100 and SeriesController.php:93-100 have catch blocks that use FLASH_TYPE_SUCCESS for exceptions, and the success message is added unconditionally after the try-catch block, causing users to see success messages even when deletion fails.

### Fix Plan
- Change FLASH_TYPE_SUCCESS to FLASH_TYPE_ERROR in both catch blocks
- Add early return after exception handling to prevent success message
- Ensure successful deletes still show success message as before

### Verification
- Test successful series/stage deletion shows success message
- Test failed series/stage deletion shows error message only
- Run existing PHPUnit tests to ensure no regressions
- Verify PHP CS Fixer and PHPStan pass

### Test Coverage
- Test included: no
- Reason: No existing test infrastructure for controller flash messages found in repository context. Adding controller tests would require significant test setup not present in current codebase.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 2
- Productive lines: 8
- Changed files: src/Controller/Administration/SeriesController.php, src/Controller/Administration/StageController.php

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-57/artefacts-20260615-090815`

Closes #57
