### PR TITLE
Fix #58: Use series-specific not-found message when saving series

### DIFF
--- a/src/Controller/Administration/SeriesController.php
+++ b/src/Controller/Administration/SeriesController.php
@@ -54,7 +54,7 @@ class SeriesController extends AbstractController
 
         $series = $this->earthAgeSeriesRepository->getSeries($isCreate, $request->get('id'));
         if (!$series instanceof EarthAgeSeries) {
-            $this->addFlash(Defaults::FLASH_TYPE_ERROR, sprintf($this->translator->trans('admin.series.messages.cannotFindSystem'), $request->get('id')));
+            $this->addFlash(Defaults::FLASH_TYPE_ERROR, sprintf($this->translator->trans('admin.series.messages.cannotFindSeries'), $request->get('id')));
 
             return $this->redirectToRoute('app_admin_series');
         }


### PR DESCRIPTION
## DE

### Problem
Bug in SeriesController where wrong translation key 'admin.series.messages.cannotFindSystem' is used instead of 'admin.series.messages.cannotFindSeries' when a series is not found.

### Diagnose
In SeriesController::save() at line 55-59, when getSeries() returns null, the error flash uses 'admin.series.messages.cannotFindSystem' but should use 'admin.series.messages.cannotFindSeries'. The delete method already correctly uses the series-specific message.

### Fixplan
- Change the translation key from 'admin.series.messages.cannotFindSystem' to 'admin.series.messages.cannotFindSeries' in SeriesController::save() method at line 55

### Verifikation
- Test the save method with an invalid series ID to confirm correct error message is shown
- Verify that existing create/edit flows still work properly
- Check that the delete method continues using the correct translation key

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a simple translation key fix that doesn't require a regression test. The existing functionality can be verified manually through the admin interface.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 2
- Geaenderte Dateien: src/Controller/Administration/SeriesController.php

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-58/artefacts-20260615-132421`

## EN

### Problem
Bug in SeriesController where wrong translation key 'admin.series.messages.cannotFindSystem' is used instead of 'admin.series.messages.cannotFindSeries' when a series is not found.

### Diagnosis
In SeriesController::save() at line 55-59, when getSeries() returns null, the error flash uses 'admin.series.messages.cannotFindSystem' but should use 'admin.series.messages.cannotFindSeries'. The delete method already correctly uses the series-specific message.

### Fix Plan
- Change the translation key from 'admin.series.messages.cannotFindSystem' to 'admin.series.messages.cannotFindSeries' in SeriesController::save() method at line 55

### Verification
- Test the save method with an invalid series ID to confirm correct error message is shown
- Verify that existing create/edit flows still work properly
- Check that the delete method continues using the correct translation key

### Test Coverage
- Test included: no
- Reason: This is a simple translation key fix that doesn't require a regression test. The existing functionality can be verified manually through the admin interface.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 2
- Changed files: src/Controller/Administration/SeriesController.php

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-58/artefacts-20260615-132421`

Closes #58
