### PR TITLE
Fix #55: Fix invalid Bootstrap spacing class in import progress UI

### DIFF
--- a/javascript/src/Admin/Import/Import.js
+++ b/javascript/src/Admin/Import/Import.js
@@ -212,7 +212,7 @@ export default class Import {
         label.innerText = this._getTranslation(status.type);
 
         const progressBarContainer = document.createElement('div');
-        progressBarContainer.classList.add('mb3');
+        progressBarContainer.classList.add('mb-3');
         progressBarContainer.append(label);
         progressBarContainer.append(progressBarWrapper);
 


### PR DESCRIPTION
## DE

### Problem
Bootstrap spacing class bug in Import.js - invalid 'mb3' class needs to be changed to valid 'mb-3' class for proper margin-bottom styling.

### Diagnose
The issue is clearly visible in `javascript/src/Admin/Import/Import.js` at line 215 where `progressBarContainer.classList.add('mb3');` uses an invalid Bootstrap class. Bootstrap requires `mb-3` (with dash) for margin-bottom-3 spacing, not `mb3`.

### Fixplan
- Change the invalid Bootstrap class 'mb3' to valid 'mb-3' in the _addProgressBar() method
- This is a simple one-line fix that replaces the incorrect class name with the proper Bootstrap spacing utility class
- Verify the JavaScript build still works after the change

### Verifikation
- Run the JavaScript build process to ensure no syntax errors: cd javascript && npm run build
- Manually test the import UI to verify proper vertical spacing appears between progress bars
- Check that other Bootstrap styling continues to work as expected

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a simple CSS class name fix in JavaScript frontend code. The repository doesn't appear to have JavaScript unit tests for UI styling, and a test for CSS class naming would be artificial and not provide meaningful value.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 1

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 2
- Geaenderte Dateien: javascript/src/Admin/Import/Import.js

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-55/artefacts-20260615-133444`

## EN

### Problem
Bootstrap spacing class bug in Import.js - invalid 'mb3' class needs to be changed to valid 'mb-3' class for proper margin-bottom styling.

### Diagnosis
The issue is clearly visible in `javascript/src/Admin/Import/Import.js` at line 215 where `progressBarContainer.classList.add('mb3');` uses an invalid Bootstrap class. Bootstrap requires `mb-3` (with dash) for margin-bottom-3 spacing, not `mb3`.

### Fix Plan
- Change the invalid Bootstrap class 'mb3' to valid 'mb-3' in the _addProgressBar() method
- This is a simple one-line fix that replaces the incorrect class name with the proper Bootstrap spacing utility class
- Verify the JavaScript build still works after the change

### Verification
- Run the JavaScript build process to ensure no syntax errors: cd javascript && npm run build
- Manually test the import UI to verify proper vertical spacing appears between progress bars
- Check that other Bootstrap styling continues to work as expected

### Test Coverage
- Test included: no
- Reason: This is a simple CSS class name fix in JavaScript frontend code. The repository doesn't appear to have JavaScript unit tests for UI styling, and a test for CSS class naming would be artificial and not provide meaningful value.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 1

### Diff
- Productive files: 1
- Productive lines: 2
- Changed files: javascript/src/Admin/Import/Import.js

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-55/artefacts-20260615-133444`

Closes #55
