### PR TITLE
fix: correct route path typo srage -> stage in clearFilter route

### DIFF
--- a/src/Controller/Administration/StageController.php
+++ b/src/Controller/Administration/StageController.php
@@ -103,7 +103,7 @@ class StageController extends AbstractController
         return $this->redirectToRoute('app_admin_series');
     }
 
-    #[Route('/admin/srage/clear/filter', name: 'app_admin_stage_clear_filter')]
+    #[Route('/admin/stage/clear/filter', name: 'app_admin_stage_clear_filter')]
     public function clearFilter(): Response
     {
         (new FilterBuilder())->clear();


### PR DESCRIPTION
## Summary

Fixes #62 - Typo in stage clear-filter route path.

The route was registered as `/admin/srage/clear/filter` but should be `/admin/stage/clear/filter` for consistency with other stage routes (e.g. `/admin/stage`, `/admin/stage/save`).

## Changes

- `src/Controller/Administration/StageController.php:106`: Fixed route path from `/admin/srage/clear/filter` to `/admin/stage/clear/filter`

The Twig template (`templates/administration/stage/index.html.twig`) uses the route name `app_admin_stage_clear_filter` to generate the URL, so it will automatically generate the correct path once this fix is applied.