### PR TITLE
Fix #56: Escape fossil number in delete confirmation modal

### DIFF
--- a/javascript/src/Admin/Fossil/DeleteFossil.js
+++ b/javascript/src/Admin/Fossil/DeleteFossil.js
@@ -60,7 +60,26 @@ export default class DeleteFossil {
 
     _createModalContent(number) {
         const div = document.createElement('div');
-        div.innerHTML = window.translations.trans('admin.fossil.deleteFossilMessage').replace('%s', number);
+        const message = window.translations.trans('admin.fossil.deleteFossilMessage');
+        const placeholderIndex = message.indexOf('%s');
+
+        if (placeholderIndex === -1) {
+            // No placeholder in the translation: render the message markup as-is
+            // without interpolating any user-controlled value.
+            div.innerHTML = message;
+        } else {
+            const before = document.createElement('span');
+            before.innerHTML = message.slice(0, placeholderIndex);
+
+            const after = document.createElement('span');
+            after.innerHTML = message.slice(placeholderIndex + 2);
+
+            // Insert the fossil number as text so it cannot be interpreted as HTML.
+            div.appendChild(before);
+            div.appendChild(document.createTextNode(number));
+            div.appendChild(after);
+        }
+
         this.confirmInput = this.createConfirmInput();
 
         const innerDiv = document.createElement('div');


### PR DESCRIPTION
## DE

### Problem
DOM-XSS risk in the admin fossil delete confirmation dialog: the fossil number is read from button.dataset.number and interpolated into a translated message via String.replace, then assigned to div.innerHTML. The translation contains required HTML (<b>(%s)</b>), so the number must be rendered as text while keeping the surrounding markup. existing_pull_request is null; the two prior comments are historical automation failures (Anthropic 404 model error and a payload validation error) and do not represent a current PR.

### Diagnose
In javascript/src/Admin/Fossil/DeleteFossil.js the _createModalContent method sets div.innerHTML = window.translations.trans('admin.fossil.deleteFossilMessage').replace('%s', number). The translation 'admin.fossil.deleteFossilMessage' (translations/messages.en.yml) is 'Do you really want to delete the Fossil? To confirm, please type the Fossil number <b>(%s)</b> in the input field below.', so the message itself contains intentional <b> markup. The %s placeholder is replaced with the raw, unescaped fossil number coming from button.dataset.number, then the whole string is parsed as HTML via innerHTML. A fossil number containing HTML (e.g. <img src=x onerror=alert(1)>) is therefore interpreted as markup when the delete dialog opens. The fix must escape only the interpolated number while preserving the surrounding translated markup.

### Fixplan
- In _createModalContent, stop assigning the interpolated user value via innerHTML. Split the translated message on the %s placeholder and build DOM nodes so the static parts keep their markup while the fossil number is inserted as a text node.
- Set the static translation segments (which contain the intended <b> markup) into span elements via innerHTML before/after the placeholder, and append the fossil number using document.createTextNode so it cannot be parsed as HTML.
- Keep the rest of the flow (confirm input creation, appending, confirm callback comparing confirmInput.value to number) unchanged so the delete-confirm flow still works.
- Document the limitation that no JS unit-test harness exists in the repository so verification is via build plus manual reproduction.

### Verifikation
- Run the JS build: cd javascript && npm install && npm run build to ensure the changed module compiles.
- Manually open the admin fossil delete dialog for a fossil whose number is <img src=x onerror=alert(1)> and confirm the number is shown verbatim as text, the <b>(...)</b> formatting from the translation is still bold, and no script/img side effect occurs.
- Confirm the confirm-delete flow still works: typing the exact fossil number enables successful deletion and a mismatched value shows the is-invalid state.
- If a JS unit-test harness exists in the repository, run it to execute any added regression test.

### Testabdeckung
- Test enthalten: nein
- Begruendung: The repository_context shows only a built public/ bundle and source JS modules; no existing JavaScript unit-test harness (e.g. jest/vitest config or a tests directory for javascript/src) is visible, and the project's automated tests are PHPUnit and browser-dependent Playwright e2e. Adding a new JS test framework would violate the 'do not introduce a new test harness/dependency' guidance. Verification is therefore via the build step and the manual reproduction steps. If a JS unit-test setup already exists in the repo (not shown here), a focused test asserting _createModalContent renders the number as a text node should be added following that convention.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 21
- Geaenderte Dateien: javascript/src/Admin/Fossil/DeleteFossil.js

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-56/artefacts-20260616-053031`

## EN

### Problem
DOM-XSS risk in the admin fossil delete confirmation dialog: the fossil number is read from button.dataset.number and interpolated into a translated message via String.replace, then assigned to div.innerHTML. The translation contains required HTML (<b>(%s)</b>), so the number must be rendered as text while keeping the surrounding markup. existing_pull_request is null; the two prior comments are historical automation failures (Anthropic 404 model error and a payload validation error) and do not represent a current PR.

### Diagnosis
In javascript/src/Admin/Fossil/DeleteFossil.js the _createModalContent method sets div.innerHTML = window.translations.trans('admin.fossil.deleteFossilMessage').replace('%s', number). The translation 'admin.fossil.deleteFossilMessage' (translations/messages.en.yml) is 'Do you really want to delete the Fossil? To confirm, please type the Fossil number <b>(%s)</b> in the input field below.', so the message itself contains intentional <b> markup. The %s placeholder is replaced with the raw, unescaped fossil number coming from button.dataset.number, then the whole string is parsed as HTML via innerHTML. A fossil number containing HTML (e.g. <img src=x onerror=alert(1)>) is therefore interpreted as markup when the delete dialog opens. The fix must escape only the interpolated number while preserving the surrounding translated markup.

### Fix Plan
- In _createModalContent, stop assigning the interpolated user value via innerHTML. Split the translated message on the %s placeholder and build DOM nodes so the static parts keep their markup while the fossil number is inserted as a text node.
- Set the static translation segments (which contain the intended <b> markup) into span elements via innerHTML before/after the placeholder, and append the fossil number using document.createTextNode so it cannot be parsed as HTML.
- Keep the rest of the flow (confirm input creation, appending, confirm callback comparing confirmInput.value to number) unchanged so the delete-confirm flow still works.
- Document the limitation that no JS unit-test harness exists in the repository so verification is via build plus manual reproduction.

### Verification
- Run the JS build: cd javascript && npm install && npm run build to ensure the changed module compiles.
- Manually open the admin fossil delete dialog for a fossil whose number is <img src=x onerror=alert(1)> and confirm the number is shown verbatim as text, the <b>(...)</b> formatting from the translation is still bold, and no script/img side effect occurs.
- Confirm the confirm-delete flow still works: typing the exact fossil number enables successful deletion and a mismatched value shows the is-invalid state.
- If a JS unit-test harness exists in the repository, run it to execute any added regression test.

### Test Coverage
- Test included: no
- Reason: The repository_context shows only a built public/ bundle and source JS modules; no existing JavaScript unit-test harness (e.g. jest/vitest config or a tests directory for javascript/src) is visible, and the project's automated tests are PHPUnit and browser-dependent Playwright e2e. Adding a new JS test framework would violate the 'do not introduce a new test harness/dependency' guidance. Verification is therefore via the build step and the manual reproduction steps. If a JS unit-test setup already exists in the repo (not shown here), a focused test asserting _createModalContent renders the number as a text node should be added following that convention.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 21
- Changed files: javascript/src/Admin/Fossil/DeleteFossil.js

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-56/artefacts-20260616-053031`

Closes #56
