### PR TITLE
Fix #68: Generate translations before frontend build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
     build-fossil-catalog:
         timeout-minutes: 36
         runs-on: ubuntu-latest
+        env:
+            APP_SECRET: build-workflow-secret
+            LANGUAGE: de
 
         steps:
             -   name: Checkout repository
@@ -27,6 +30,10 @@ jobs:
                 run: |
                     composer install
 
+            -   name: Install translations
+                run: |
+                    php bin/console app:install-translations
+
             -   uses: actions/setup-node@v3
                 with:
                     node-version: 18
@@ -40,7 +47,3 @@ jobs:
                 run: |
                     cd javascript
                     npm run build
-
-            -   name: Install translations
-                run: |
-                    php bin/console app:install-translations

--- a/.github/workflows/relase.yml
+++ b/.github/workflows/relase.yml
@@ -9,6 +9,9 @@ on:
 jobs:
     release:
         runs-on: ubuntu-latest
+        env:
+            APP_SECRET: build-workflow-secret
+            LANGUAGE: de
         steps:
             -   name: Checkout repository
                 uses: actions/checkout@v4


### PR DESCRIPTION
## DE

### Problem
Der Frontend-Build importiert `javascript/src/translations/messages.json` und `messages_defaults.json`. Diese Dateien werden erst durch `php bin/console app:install-translations` erzeugt und sind bewusst gitignored. Im Build-Workflow lief der JS-Build vorher, wodurch ein sauberer CI-Checkout die Module nicht aufloesen kann. Zusaetzlich darf der CI-Job fuer `LANGUAGE` nicht auf den Platzhalter aus `.env.dist` fallen.

### Fix
- `app:install-translations` laeuft im Build-Workflow vor `npm run build`.
- Build- und Release-Workflow setzen deterministische Build-Env-Werte fuer `APP_SECRET` und `LANGUAGE=de`.
- Generierte Translation-/JS-Dateien bleiben weiterhin untracked.

### Verifikation
- `php -r` YAML-Parse fuer `.github/workflows/build.yml` und `.github/workflows/relase.yml`
- `APP_SECRET=build-workflow-secret LANGUAGE=de php bin/console app:install-translations`
- `cd javascript && npm install`
- `cd javascript && npm run build`
- `composer phpunit` (gruen, bestehendes PHPUnit-Warning: keine Tests in `UpdaterTest`)

### Lokale Grenzen
- `composer fix-cs-dry` ist lokal blockiert, weil der gelockte PHP-CS-Fixer PHP 8.4.22 ablehnt; CI nutzt PHP 8.3.
- `composer phpstan` ist lokal durch den gelockten PHPStan-Build auf PHP 8.4.22 blockiert; CI nutzt PHP 8.3.
- `composer validate --strict` meldet bestehende Package-Metadaten/Lockfile-Themen, nicht diese Workflow-Aenderung.

## EN

### Problem
The frontend build imports `javascript/src/translations/messages.json` and `messages_defaults.json`. Those files are generated by `php bin/console app:install-translations` and are intentionally gitignored. The Build workflow ran the JS build before generating them, so a clean CI checkout can fail module resolution. The CI jobs also need a real `LANGUAGE` value instead of the placeholder from `.env.dist`.

### Fix
- Run `app:install-translations` before `npm run build` in the Build workflow.
- Set deterministic build-only `APP_SECRET` and `LANGUAGE=de` values in Build and Release workflows.
- Keep generated translation and JS assets untracked.

### Verification
- `php -r` YAML parse for `.github/workflows/build.yml` and `.github/workflows/relase.yml`
- `APP_SECRET=build-workflow-secret LANGUAGE=de php bin/console app:install-translations`
- `cd javascript && npm install`
- `cd javascript && npm run build`
- `composer phpunit` (green, existing PHPUnit warning: no tests in `UpdaterTest`)

### Local limits
- `composer fix-cs-dry` is locally blocked because the locked PHP-CS-Fixer rejects PHP 8.4.22; CI uses PHP 8.3.
- `composer phpstan` is locally blocked by the locked PHPStan build on PHP 8.4.22; CI uses PHP 8.3.
- `composer validate --strict` reports existing package metadata/lockfile issues, not this workflow change.

Closes #68