### PR TITLE
Fix #62: Fix typo in stage clear-filter route path

### DIFF
--- a/src/Controller/Administration/StageController.php
+++ b/src/Controller/Administration/StageController.php
@@ -103,7 +103,7 @@ class StageController extends AbstractController
         return $this->redirectToRoute('app_admin_series');
     }
 
-    #[Route('/admin/srage/clear/filter', name: 'app_admin_stage_clear_filter')]
+    #[Route('/admin/stage/clear/filter', name: 'app_admin_stage_clear_filter')]
     public function clearFilter(): Response
     {
         (new FilterBuilder())->clear();


### PR DESCRIPTION
## DE

### Problem
Issue #62 reports a typo in the Symfony route path for the stage clear-filter action: the route is registered as `/admin/srage/clear/filter` instead of `/admin/stage/clear/filter`. The route name `app_admin_stage_clear_filter` is correct, so the link works, but the visible/callable path is misspelled. existing_pull_request is null; comments mention a historical PR #66 on a fork branch, which is not a current structured existing PR and must be ignored per policy.

### Diagnose
repository_context for src/Controller/Administration/StageController.php shows the clearFilter action annotated with #[Route('/admin/srage/clear/filter', name: 'app_admin_stage_clear_filter')]. The path segment 'srage' is a clear typo for 'stage'. The route name is correct, so generated links resolve, but the literal URL path is misspelled and /admin/stage/clear/filter does not exist. Fix is a single-character path correction with no behavioral risk.

### Fixplan
- In src/Controller/Administration/StageController.php, correct the Route path attribute for the clearFilter action from '/admin/srage/clear/filter' to '/admin/stage/clear/filter'.
- Keep the route name 'app_admin_stage_clear_filter' unchanged so the template link generation continues to work.
- No template change is required because the link uses the route name (path()) rather than a hardcoded URL.

### Verifikation
- Run composer fix-cs-dry to confirm code style passes.
- Run composer phpstan to confirm static analysis passes.
- Run composer phpunit to confirm unit tests pass.
- Manually verify that the stage clear-filter link now generates /admin/stage/clear/filter and that visiting that path resets the stage filters and redirects to app_admin_stage.

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a one-character route-path typo fix. A meaningful regression test would require a functional/WebTestCase route assertion. The repository_context provided no existing PHPUnit controller/route test pattern for these admin controllers, and the framework guidance forbids introducing new test harnesses or instantiating controllers/repositories outside existing patterns. Manual verification plus the existing CI (phpstan, cs-fixer, phpunit, and Playwright E2E) covers the change. Adding a new test harness here would violate the no-new-pattern guidance.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 2
- Geaenderte Dateien: src/Controller/Administration/StageController.php

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-62/artefacts-20260616-064309`

## EN

### Problem
Issue #62 reports a typo in the Symfony route path for the stage clear-filter action: the route is registered as `/admin/srage/clear/filter` instead of `/admin/stage/clear/filter`. The route name `app_admin_stage_clear_filter` is correct, so the link works, but the visible/callable path is misspelled. existing_pull_request is null; comments mention a historical PR #66 on a fork branch, which is not a current structured existing PR and must be ignored per policy.

### Diagnosis
repository_context for src/Controller/Administration/StageController.php shows the clearFilter action annotated with #[Route('/admin/srage/clear/filter', name: 'app_admin_stage_clear_filter')]. The path segment 'srage' is a clear typo for 'stage'. The route name is correct, so generated links resolve, but the literal URL path is misspelled and /admin/stage/clear/filter does not exist. Fix is a single-character path correction with no behavioral risk.

### Fix Plan
- In src/Controller/Administration/StageController.php, correct the Route path attribute for the clearFilter action from '/admin/srage/clear/filter' to '/admin/stage/clear/filter'.
- Keep the route name 'app_admin_stage_clear_filter' unchanged so the template link generation continues to work.
- No template change is required because the link uses the route name (path()) rather than a hardcoded URL.

### Verification
- Run composer fix-cs-dry to confirm code style passes.
- Run composer phpstan to confirm static analysis passes.
- Run composer phpunit to confirm unit tests pass.
- Manually verify that the stage clear-filter link now generates /admin/stage/clear/filter and that visiting that path resets the stage filters and redirects to app_admin_stage.

### Test Coverage
- Test included: no
- Reason: This is a one-character route-path typo fix. A meaningful regression test would require a functional/WebTestCase route assertion. The repository_context provided no existing PHPUnit controller/route test pattern for these admin controllers, and the framework guidance forbids introducing new test harnesses or instantiating controllers/repositories outside existing patterns. Manual verification plus the existing CI (phpstan, cs-fixer, phpunit, and Playwright E2E) covers the change. Adding a new test harness here would violate the no-new-pattern guidance.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 2
- Changed files: src/Controller/Administration/StageController.php

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-62/artefacts-20260616-064309`

Closes #62
