### PR TITLE
Fix #61: Fix helpText rendering in shared field templates

### DIFF
--- a/templates/administration/base/multi-select.html.twig
+++ b/templates/administration/base/multi-select.html.twig
@@ -8,7 +8,7 @@
 
     {% if helpText|default(null) %}
         <div class="form-text">
-            {{ helptext }}
+            {{ helpText }}
         </div>
     {% endif %}
 </div>

--- a/templates/administration/base/multiSelectField.html.twig
+++ b/templates/administration/base/multiSelectField.html.twig
@@ -16,7 +16,7 @@
 
     {% if helpText|default(null) %}
         <div class="form-text">
-            {{ helptext }}
+            {{ helpText }}
         </div>
     {% endif %}
 </div>

--- a/templates/administration/base/system-series-stage-select.html.twig
+++ b/templates/administration/base/system-series-stage-select.html.twig
@@ -13,7 +13,7 @@
     </select>
     {% if helpText|default(null) %}
         <div class="form-text">
-            {{ helptext }}
+            {{ helpText }}
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
## DE

### Problem
Three shared Twig field templates check `helpText` in the condition but render the lowercase `helptext`. Because Twig is case-sensitive, the help-text block renders empty when an include passes `helpText`. Fix is to render `{{ helpText }}` in all three templates.

### Diagnose
repository_context confirms all three named templates contain the pattern `{% if helpText|default(null) %}` followed by `{{ helptext }}`. The condition variable (`helpText`) and the output variable (`helptext`) differ only in case. Twig variable names are case-sensitive, so when an include provides `helpText`, the condition is truthy but `helptext` is undefined and the form-text div is empty. Affected files: templates/administration/base/multi-select.html.twig, templates/administration/base/multiSelectField.html.twig, templates/administration/base/system-series-stage-select.html.twig.

### Fixplan
- In templates/administration/base/multi-select.html.twig replace the output `{{ helptext }}` with `{{ helpText }}`.
- In templates/administration/base/multiSelectField.html.twig replace `{{ helptext }}` with `{{ helpText }}`.
- In templates/administration/base/system-series-stage-select.html.twig replace `{{ helptext }}` with `{{ helpText }}`.
- Leave the existing `{% if helpText|default(null) %}` conditions unchanged so templates without help text remain unaffected.

### Verifikation
- Manually render an admin form including each affected template with a non-empty `helpText` and confirm the text appears in the `form-text` div.
- Render a template include without `helpText` and confirm no help-text block content is shown.
- Optionally run composer phpunit to confirm no regressions, though no PHP code changes are involved.

### Testabdeckung
- Test enthalten: nein
- Begruendung: The repository has no Twig rendering/unit test harness for these presentational templates (tests are PHPUnit integration and Playwright E2E only). Adding a bespoke Twig render test would introduce a new test pattern not present in the repo. The change is a trivial case-only variable correction; verification is best done via manual rendering and existing E2E coverage.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 3
- Produktive Zeilen: 6
- Geaenderte Dateien: templates/administration/base/multi-select.html.twig, templates/administration/base/multiSelectField.html.twig, templates/administration/base/system-series-stage-select.html.twig

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-61/artefacts-20260616-070810`

## EN

### Problem
Three shared Twig field templates check `helpText` in the condition but render the lowercase `helptext`. Because Twig is case-sensitive, the help-text block renders empty when an include passes `helpText`. Fix is to render `{{ helpText }}` in all three templates.

### Diagnosis
repository_context confirms all three named templates contain the pattern `{% if helpText|default(null) %}` followed by `{{ helptext }}`. The condition variable (`helpText`) and the output variable (`helptext`) differ only in case. Twig variable names are case-sensitive, so when an include provides `helpText`, the condition is truthy but `helptext` is undefined and the form-text div is empty. Affected files: templates/administration/base/multi-select.html.twig, templates/administration/base/multiSelectField.html.twig, templates/administration/base/system-series-stage-select.html.twig.

### Fix Plan
- In templates/administration/base/multi-select.html.twig replace the output `{{ helptext }}` with `{{ helpText }}`.
- In templates/administration/base/multiSelectField.html.twig replace `{{ helptext }}` with `{{ helpText }}`.
- In templates/administration/base/system-series-stage-select.html.twig replace `{{ helptext }}` with `{{ helpText }}`.
- Leave the existing `{% if helpText|default(null) %}` conditions unchanged so templates without help text remain unaffected.

### Verification
- Manually render an admin form including each affected template with a non-empty `helpText` and confirm the text appears in the `form-text` div.
- Render a template include without `helpText` and confirm no help-text block content is shown.
- Optionally run composer phpunit to confirm no regressions, though no PHP code changes are involved.

### Test Coverage
- Test included: no
- Reason: The repository has no Twig rendering/unit test harness for these presentational templates (tests are PHPUnit integration and Playwright E2E only). Adding a bespoke Twig render test would introduce a new test pattern not present in the repo. The change is a trivial case-only variable correction; verification is best done via manual rendering and existing E2E coverage.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 3
- Productive lines: 6
- Changed files: templates/administration/base/multi-select.html.twig, templates/administration/base/multiSelectField.html.twig, templates/administration/base/system-series-stage-select.html.twig

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-61/artefacts-20260616-070810`

Closes #61
