### PR TITLE
Fix #75: Fix malformed pagination item class attribute

### DIFF
--- a/templates/pagination.html.twig
+++ b/templates/pagination.html.twig
@@ -7,7 +7,7 @@
 
             {% for i in startPage..endPage %}
 
-                <li class="page-item{% if page == i %} active"{% endif %} aria-current="page">
+                <li class="page-item{% if page == i %} active{% endif %}" aria-current="page">
                     <a class="page-link" href="#" data-page="{{ i }}">{{ i }}</a>
                 </li>
 


### PR DESCRIPTION
## DE

### Problem
Issue #75 reports malformed HTML in templates/pagination.html.twig:10 where the closing quote of the class attribute is placed inside the {% if page == i %} condition, producing invalid markup for inactive pages. The fix is to move the closing quote outside the condition so the class attribute is always valid.

### Diagnose
repository_context shows templates/pagination.html.twig contains the line `<li class="page-item{% if page == i %} active"{% endif %} aria-current="page">`. The closing double quote sits inside the if block, so when page != i the class attribute is left unterminated, producing invalid HTML. Active pages still close because the quote is rendered only inside the conditional. This matches the issue exactly.

### Fixplan
- Edit templates/pagination.html.twig line 10 so the closing quote of the class attribute is outside the {% if page == i %} conditional.
- Render `class="page-item{% if page == i %} active{% endif %}"` so inactive pages render class="page-item" and active pages render class="page-item active".
- Keep aria-current="page" as-is per acceptance criteria so it remains intentionally present and valid.

### Verifikation
- Render the pagination template and confirm that for page != i the markup is `<li class="page-item" aria-current="page">`.
- Confirm that for page == i the markup is `<li class="page-item active" aria-current="page">`.
- Validate the rendered HTML has no unterminated attributes.
- Optionally run the existing E2E/Playwright suite locally if available to confirm the admin list pagination renders correctly.

### Testabdeckung
- Test enthalten: nein
- Begruendung: The repository contains PHPUnit (composer phpunit) and Playwright E2E tests, but no existing Twig template-rendering unit test pattern is shown in the provided context for a small markup snippet. Adding a Twig render test would require introducing a new test harness not evidenced in the repo. The change is a one-line template markup correction best verified via the existing E2E rendering of admin list views; introducing a new test pattern would violate the no-new-abstraction guidance.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 2
- Geaenderte Dateien: templates/pagination.html.twig

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-75/artefacts-20260616-085519`

## EN

### Problem
Issue #75 reports malformed HTML in templates/pagination.html.twig:10 where the closing quote of the class attribute is placed inside the {% if page == i %} condition, producing invalid markup for inactive pages. The fix is to move the closing quote outside the condition so the class attribute is always valid.

### Diagnosis
repository_context shows templates/pagination.html.twig contains the line `<li class="page-item{% if page == i %} active"{% endif %} aria-current="page">`. The closing double quote sits inside the if block, so when page != i the class attribute is left unterminated, producing invalid HTML. Active pages still close because the quote is rendered only inside the conditional. This matches the issue exactly.

### Fix Plan
- Edit templates/pagination.html.twig line 10 so the closing quote of the class attribute is outside the {% if page == i %} conditional.
- Render `class="page-item{% if page == i %} active{% endif %}"` so inactive pages render class="page-item" and active pages render class="page-item active".
- Keep aria-current="page" as-is per acceptance criteria so it remains intentionally present and valid.

### Verification
- Render the pagination template and confirm that for page != i the markup is `<li class="page-item" aria-current="page">`.
- Confirm that for page == i the markup is `<li class="page-item active" aria-current="page">`.
- Validate the rendered HTML has no unterminated attributes.
- Optionally run the existing E2E/Playwright suite locally if available to confirm the admin list pagination renders correctly.

### Test Coverage
- Test included: no
- Reason: The repository contains PHPUnit (composer phpunit) and Playwright E2E tests, but no existing Twig template-rendering unit test pattern is shown in the provided context for a small markup snippet. Adding a Twig render test would require introducing a new test harness not evidenced in the repo. The change is a one-line template markup correction best verified via the existing E2E rendering of admin list views; introducing a new test pattern would violate the no-new-abstraction guidance.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 2
- Changed files: templates/pagination.html.twig

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-75/artefacts-20260616-085519`

Closes #75
