### PR TITLE
Fix #74: Remove duplicate href from admin catalog nav link

### DIFF
--- a/templates/administration/nav.html.twig
+++ b/templates/administration/nav.html.twig
@@ -15,7 +15,7 @@
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav">
                         <li class="nav-item">
-                            <a href="{{ url('app_admin_fossil_list') }}" class="nav-link" aria-current="page" href="#">
+                            <a href="{{ url('app_admin_fossil_list') }}" class="nav-link" aria-current="page">
                                 <i class="bi bi-list"></i> {% trans %}admin.nav.catalog{% endtrans %}
                             </a>
                         </li>


### PR DESCRIPTION
## DE

### Problem
The admin catalog navigation link in templates/administration/nav.html.twig renders two href attributes (one pointing to app_admin_fossil_list and a leftover href="#"). The duplicate href is invalid HTML. The fix removes the trailing href="#" so the link has exactly one href pointing to app_admin_fossil_list. No existing pull request is provided.

### Diagnose
repository_context excerpt for templates/administration/nav.html.twig shows the catalog nav-link element: <a href="{{ url('app_admin_fossil_list') }}" class="nav-link" aria-current="page" href="#">. It contains two href attributes, confirming the reported invalid HTML. The remaining navigation links use a single href each.

### Fixplan
- Edit templates/administration/nav.html.twig and remove the trailing duplicate href="#" attribute from the catalog nav-link so it keeps only href="{{ url('app_admin_fossil_list') }}".
- Leave all other attributes (class, aria-current) and the rest of the navigation unchanged.

### Verifikation
- Inspect the rendered admin navigation and confirm the catalog link has exactly one href attribute pointing to app_admin_fossil_list.
- Run an HTML validator or the existing E2E/Playwright admin navigation flow to confirm no duplicate-attribute issues.
- Confirm via diff review that only the single line changed and the rest of nav.html.twig is untouched.

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a single Twig template attribute fix. The repository's PHP unit tests do not render this template in isolation, and adding a unit/integration test solely to assert markup would not follow existing conventions; navigation rendering is covered by the existing Playwright E2E flow. No useful new regression test fits the established patterns for this trivial markup correction.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 2
- Geaenderte Dateien: templates/administration/nav.html.twig

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-74/artefacts-20260616-090440`

## EN

### Problem
The admin catalog navigation link in templates/administration/nav.html.twig renders two href attributes (one pointing to app_admin_fossil_list and a leftover href="#"). The duplicate href is invalid HTML. The fix removes the trailing href="#" so the link has exactly one href pointing to app_admin_fossil_list. No existing pull request is provided.

### Diagnosis
repository_context excerpt for templates/administration/nav.html.twig shows the catalog nav-link element: <a href="{{ url('app_admin_fossil_list') }}" class="nav-link" aria-current="page" href="#">. It contains two href attributes, confirming the reported invalid HTML. The remaining navigation links use a single href each.

### Fix Plan
- Edit templates/administration/nav.html.twig and remove the trailing duplicate href="#" attribute from the catalog nav-link so it keeps only href="{{ url('app_admin_fossil_list') }}".
- Leave all other attributes (class, aria-current) and the rest of the navigation unchanged.

### Verification
- Inspect the rendered admin navigation and confirm the catalog link has exactly one href attribute pointing to app_admin_fossil_list.
- Run an HTML validator or the existing E2E/Playwright admin navigation flow to confirm no duplicate-attribute issues.
- Confirm via diff review that only the single line changed and the rest of nav.html.twig is untouched.

### Test Coverage
- Test included: no
- Reason: This is a single Twig template attribute fix. The repository's PHP unit tests do not render this template in isolation, and adding a unit/integration test solely to assert markup would not follow existing conventions; navigation rendering is covered by the existing Playwright E2E flow. No useful new regression test fits the established patterns for this trivial markup correction.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 2
- Changed files: templates/administration/nav.html.twig

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-74/artefacts-20260616-090440`

Closes #74
